### PR TITLE
Updated config for NGINX

### DIFF
--- a/src/bingo-board/default.conf.template
+++ b/src/bingo-board/default.conf.template
@@ -1,30 +1,51 @@
+# Add connection upgrade mapping (This ensures the Connection header is set correctly for WebSocket upgrades)
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+}
+
 server {
     listen 80;
 
-    error_log /var/log/nginx/error.log info;
+    # Logs should now be visible in the container logs (cat)
+    error_log /var/log/nginx/access.error.log debug;
+    access_log /var/log/nginx/server.access.log main;
 
     root /usr/share/nginx/html;
     index index.html;
-
-    access_log /var/log/nginx/server.access.log main;
 
     location / {
         try_files $uri $uri/ /index.html;
     }
 
+    # Handle SignalR hub requests (without trailing slash) - We might need to duplicate this if there is issues with the trailing slash (redirects)
     location /bingohub {
         proxy_pass ${services__boardadmin__http__0}/bingohub;
         proxy_http_version 1.1;
 
-    
-
-        # basic proxy headers
-        proxy_set_header Host              $host;
+        # basic proxy headers (most of these are the request forwarding)
+        proxy_set_header Host              $proxy_host;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-Host  $host;
 
         # WebSocket support
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_set_header Connection $connection_upgrade;
+        
+        # SignalR specific configuration
+        proxy_cache off;
+        proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 86400;
+        proxy_send_timeout 86400;
+        proxy_connect_timeout 60;
+        
+        # Disable buffering for real-time connections
+        proxy_buffering off;
+        proxy_request_buffering off;
+        
+        # Handle redirects properly
+        proxy_redirect off;
     }
 }


### PR DESCRIPTION
This pull request updates the Nginx configuration template for the Bingo Board application to improve WebSocket and SignalR support, enhance logging, and adjust proxy headers for better compatibility with real-time connections.

**WebSocket and SignalR support:**
* Added a `map` block to set the `Connection` header correctly for WebSocket upgrades, ensuring proper handling of upgrade requests.
* Updated the `/bingohub` location block with SignalR-specific proxy settings, including disabling proxy buffering, setting longer timeouts, and handling redirects to support real-time connections.

**Logging improvements:**
* Changed log file paths and increased log verbosity to make logs more visible in container environments.

**Proxy header adjustments:**
* Modified proxy headers to use `$proxy_host` for the `Host` header and added `X-Real-IP` and `X-Forwarded-Host` headers to ensure correct client information is forwarded.